### PR TITLE
Formatting and link cleanup

### DIFF
--- a/sig-security/annual-report-2021.md
+++ b/sig-security/annual-report-2021.md
@@ -1,34 +1,6 @@
-# Kubernetes SIG Security 2021 Annual Report Template
-
-
-# Checklist 
-
-
-
-*   [X] [Read about the process here](https://git.k8s.io/community/committee-steering/governance/annual-reports.md#reporting-process) (https://git.k8s.io/community/committee-steering/governance/annual-reports.md#reporting-process) 
-*   [X] Copy this template into a new document and share with your mailing list/slack channel/meeting on whatever platform (gdocs, hackmd, etc.) that the team prefers.
-*   [X] Remove sections that are not applicable (example: if you are a working group, delete the special interest group questions)
-*   [MAYBE] Pick graphs from [Devstats to pull supporting data](https://k8s.devstats.cncf.io/d/12/dashboards?orgId=1&refresh=15m) for your responses. 
-*   [TODO] Schedule a time with your Steering liaison and other Chairs, TLs, and Organizers of your group to check-in on your roles as Chair or Working Group Organizer. If anyone would rather meet 1:1, please have them reach out to the liaison directly, we are happy to. We’d like to talk about: challenges, wins, things you didn’t know before but wish you did, want to continue in the role or help finding a replacement; and lastly any feedback you have for us as a body and how we can help you succeed and feel comfortable in these leadership roles. 
-*   [TODO] PR this document into your community group directory in kubernetes/community (example: sig-architecture/) 
-    *   [ ] by March 8th, 2021
-    *   [ ] titled: annual-report-YEAR.md
-    *   [ ] are there any responses that you’d like to share privately first? [steering-private@kubernetes.io](mailto:steering-private@kubernetes.io) or tag your liaison in for discussion. 
-
-## Special Interest Groups:
-
-
-Instructions for this section:
-
-
-
-*   [ ] each response should have supporting documentation, linked KEPs, graphs, data
-*   [ ] err on the side of being descriptive with your responses. End users and others that read this might not know our upstream acronyms, shorthand, or where to find a reference. 
-
+# Kubernetes SIG Security 2021 Annual Report
 
 ## Operational
-
-
 
 *   How are you doing with operational tasks in [sig-governance.md](https://github.com/kubernetes/community/blob/master/committee-steering/governance/sig-governance.md)?
     *   Is your README accurate? have a CONTRIBUTING.md file?
@@ -44,20 +16,20 @@ Instructions for this section:
         *   Trends in community members watching recordings?
             *   [Recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP1mXOLAc9ti0oX8s_ookQCi) mostly serve as a historical record. There have been 18 SIG-related meetings between Jan 1 and April 8 2021, including the main SIG meeting and subproject meetings, which have an average of 2.94 views on YouTube.
 *   How does the group get updates, reports, or feedback from subprojects?
-        *   Subproject owners or designees talk about it in the main SIG meeting as a standing agenda item.
+    *   Subproject owners or designees talk about it in the main SIG meeting as a standing agenda item.
     *   Are there any springing up or being retired?
         *   Because we are a newer SIG, there hasn’t been much opportunity for turnover. We have two established and active subprojects: security-docs and security-audit. A third and newer, security-tooling, is just starting to spring up.
     *   Are OWNERS files up to date in these areas?
         *   Yes. As a horizontal SIG that mostly works by interacting with and contributing to other SIGs’ code and projects, we don’t have much need for OWNERS files right now. We have directories for both of the more established subprojects to ensure they are recognized.
 *   Same question as above but for working groups.
-        *   We do not currently have any working groups.
+    *   We do not currently have any working groups.
 *   When was your last monthly community-wide update? (provide link to deck and/or recording)
-        *   Since our founding in October 2020, we haven’t given a monthly community-wide update yet. We have a maintainer track session coming up at KubeCon EU 2021.
+    *   Since our founding in October 2020, we haven’t given a monthly community-wide update yet. We have a maintainer track session coming up [at KubeCon EU 2021](https://kccnceu2021.sched.com/event/iE5u/).
 
 ## Membership
 
 *   Are all listed SIG leaders (chairs, tech leads, and subproject owners) active?
-        *   Yes
+    *   Yes
 *   How do you measure membership? By mailing list members, OWNERs, or something else?
     *   We are interested in membership metrics for the purposes of gauging the health and activity of our community. This leads us to two types of measures: measures of reach and measures of collaboration.
     *   We measure reach using the number of members of our Slack channel and mailing list; these are potential future collaborators on SIG projects. As of April 8, 2021, there are 438 members of the main Slack channel and 131 members of the mailing list.
@@ -70,12 +42,12 @@ Instructions for this section:
 *   Is there a healthy onboarding and growth path for contributors in your SIG? What are some activities that the group does to encourage this? What programs are you participating in to grow contributors throughout the contributor ladder?
     *   We are onboarding and growing contributors continuously through our processes and culture. We actively practice behaviors of inclusion to help new and growing contributors feel more confident to participate. For example, we list appropriate pronouns in our meeting attendance list, and before changing subjects we pause to ask for additional comments.
     *   In addition to participating in SIG discussions, new contributors can also begin by assisting the subprojects with their tasks. Subproject members guide new contributors to where assistance is needed.
-    *   Our open environment creates space for interested contributors to become leaders [by sharing their ideas and energy]([https://twitter.com/PuDiJoglekar/status/1380205701994147845](https://twitter.com/PuDiJoglekar/status/1380205701994147845)). If someone brings an idea that other members are excited about and want to help work on, [those members can organize a subproject together](https://twitter.com/coffeeartgirl/status/1331046904306622465), and we can help them grow. 
-    *   The chairs help grow emerging leaders by keeping in close contact with them and providing 1:1 mentorship, [encouragement]([https://twitter.com/coffeeartgirl/status/1337078959020912642](https://twitter.com/coffeeartgirl/status/1337078959020912642)), and concrete help leveling up skills such as improving communication, leading more inclusive meetings, and presenting at conferences.
+    *   Our open environment creates space for interested contributors to become leaders [by sharing their ideas and energy](https://twitter.com/PuDiJoglekar/status/1380205701994147845). If someone brings an idea that other members are excited about and want to help work on, [those members can organize a subproject together](https://twitter.com/coffeeartgirl/status/1331046904306622465), and we can help them grow. 
+    *   The chairs help grow emerging leaders by keeping in close contact with them and providing 1:1 mentorship, [encouragement](https://twitter.com/coffeeartgirl/status/1337078959020912642), and concrete help leveling up skills such as improving communication, leading more inclusive meetings, and presenting at conferences.
 *   What programs do you participate in for new contributors?
     *   Our broadly welcoming culture is a good opportunity for security-minded Kubernetes users who want to get involved in the upstream Kubernetes community. We plan to extend this further by participating in formal “new contributor” programs in the future.
-*   Does the group have contributors from multiple companies/affiliations? 
-        *   Yes
+*   Does the group have contributors from multiple companies/affiliations?
+    *   Yes
     *   Can end users/companies contribute in some way that they currently are not?
         *   End users are currently contributing at all levels. Our contributors represent both end user organizations and Kubernetes vendors. Both SIG Security co-chairs work at companies that are Kubernetes end users.
 
@@ -84,13 +56,13 @@ Current initiatives and project health
 
 *   [ ] Please include links to KEPs and other supporting information that will be beneficial to multiple types of community members. 
 *   What are initiatives that should be highlighted, lauded, shout out, that your group is proud of? Currently underway? What are some of the longer tail projects that your group is working on?
-    *   We’re proud of the work that our security-docs subproject has started to create a Kubernetes hardening guide. They have collected contributions from across the Kubernetes community into a document outline, and now they’re writing it as a team. You may learn more about this effort in the Kubernetes SIG Security Docs Subproject [meeting notes]([https://docs.google.com/document/d/11LZn7qWB0OzbpF8va_YYGQE4fuRARCGY9KL87hwBLBI](https://docs.google.com/document/d/11LZn7qWB0OzbpF8va_YYGQE4fuRARCGY9KL87hwBLBI)). Our third-party security audit subproject is moving forward through the complexity of organizing an audit of one of the world’s largest open-source projects. The key challenges are the scale of our codebase and limited auditor experience with the Go language and cloud-native technologies. They are utilizing members’ existing relationships with audit firms, as well as building new ones, to find solutions to these challenges. 
-    *   PodSecurityPolicy was deprecated in the Kubernetes 1.21 release, and SIG Security worked closely with SIG Auth to figure out what comes next. We are delighted to have contributed to [KEP 2579]([https://github.com/kubernetes/enhancements/issues/2579](https://github.com/kubernetes/enhancements/issues/2579)) by writing and reviewing proposals, adding our members’ voices to the design meetings, and [blogging about it for the broader Kubernetes community]([https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/)). We hope to make our close collaboration with SIG Auth a model for future cross-SIG efforts throughout Kubernetes. Thanks again to everyone who has been involved!
+    *   We’re proud of the work that our security-docs subproject has started to create a Kubernetes hardening guide. They have collected contributions from across the Kubernetes community into a document outline, and now they’re writing it as a team. You may learn more about this effort in the Kubernetes SIG Security Docs Subproject [meeting notes](https://docs.google.com/document/d/11LZn7qWB0OzbpF8va_YYGQE4fuRARCGY9KL87hwBLBI). Our third-party security audit subproject is moving forward through the complexity of organizing an audit of one of the world’s largest open-source projects. The key challenges are the scale of our codebase and limited auditor experience with the Go language and cloud-native technologies. They are utilizing members’ existing relationships with audit firms, as well as building new ones, to find solutions to these challenges. 
+    *   PodSecurityPolicy was deprecated in the Kubernetes 1.21 release, and SIG Security worked closely with SIG Auth to figure out what comes next. We are delighted to have contributed to [KEP 2579](https://github.com/kubernetes/enhancements/issues/2579) by writing and reviewing proposals, adding our members’ voices to the design meetings, and [blogging about it for the broader Kubernetes community](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/). We hope to make our close collaboration with SIG Auth a model for future cross-SIG efforts throughout Kubernetes. Thanks again to everyone who has been involved!
 *   Year to date KEP work review: What’s now stable? Beta? Alpha? Road to alpha?
-    *   We have accepted stewardship of KEPs [1753]([https://github.com/kubernetes/enhancements/issues/1753](https://github.com/kubernetes/enhancements/issues/1753)) and [1933]([https://github.com/kubernetes/enhancements/issues/1933](https://github.com/kubernetes/enhancements/issues/1933)) from SIG Instrumentation. Their owners and progress remain the same, and we look forward to helping them move toward graduation.
-    *   KEP [1933]([https://github.com/kubernetes/enhancements/issues/1933](https://github.com/kubernetes/enhancements/issues/1933)) - Defend against logging secrets via static analysis - [graduated](https://github.com/kubernetes/test-infra/pull/20836) to General Availability! As a SIG, we will continue to provide review and technical input for future static analysis rule updates.
+    *   We have accepted stewardship of KEPs [1753](https://github.com/kubernetes/enhancements/issues/1753) and [1933](https://github.com/kubernetes/enhancements/issues/1933) from SIG Instrumentation. Their owners and progress remain the same, and we look forward to helping them move toward graduation.
+    *   KEP [1933](https://github.com/kubernetes/enhancements/issues/1933) - Defend against logging secrets via static analysis - [graduated](https://github.com/kubernetes/test-infra/pull/20836) to General Availability! As a SIG, we will continue to provide review and technical input for future static analysis rule updates.
     *   KEP [2568](https://github.com/kubernetes/enhancements/issues/2568) - Run control-plane as non-root in kubeadm - has been maturing steadily with help from the Kubernetes community. SIG Security has provided a forum to discuss it and feedback to advance it toward implementable status.
-    *   KEP [1981]([https://github.com/kubernetes/enhancements/issues/1981](https://github.com/kubernetes/enhancements/issues/1981)) - Support for Windows privileged containers - has matured toward alpha, including SIG Security member feedback. Nice work, team!
+    *   KEP [1981](https://github.com/kubernetes/enhancements/issues/1981) - Support for Windows privileged containers - has matured toward alpha, including SIG Security member feedback. Nice work, team!
 *   What areas and/or subprojects does the group need the most help with?
     *   We always welcome help from anyone aligned with our vision of improving Kubernetes security by learning together, sharing our expertise, and encouraging cross-SIG collaboration. Ideally, we would like to eventually have participating members with crossover to every SIG, providing a natural conduit of ideas and forming a network of helpful hackers throughout Kubernetes.
     *   As a newer SIG with a broad mission, our most pressing needs right now are around outreach and expertise.
@@ -101,7 +73,7 @@ Current initiatives and project health
             *   Come to our meetings and get more involved! If you have friends who are interested in Kubernetes security, encourage them to come and bring their energy and ideas too. We’d love to see you and hear what you have to say!
         *   To bring additional expertise to the table and help balance the load for SIG Leads, we would like to grow new Leads in the future, and are determining how best to implement the Tech Lead role in a SIG like ours. We would like to grow one or two interested members into that new role, and will be looking for help with this bootstrapping process when that time comes.
 *   What's the average open days of a PR and Issue in your group?
-        *   As a SIG who doesn’t own code in a project that encourages non-code contributions, we find the question of which PRs and issues belong to us to be difficult to answer, and would like to encourage further inclusivity of different kinds of contribution in questions on future reports.
+    *   As a SIG who doesn’t own code in a project that encourages non-code contributions, we find the question of which PRs and issues belong to us to be difficult to answer, and would like to encourage further inclusivity of different kinds of contribution in questions on future reports.
     *   What metrics does your group care about and/or measure?
         *   The metrics we are most immediately interested in are community engagement metrics, as discussed above under “Membership”.
         *   As we grow and mature as a SIG, we seek to better understand how well we are achieving our overall goal of holistically improving Kubernetes security. To do so, we’d like to find metrics that help answer questions like these:


### PR DESCRIPTION
* Removed "Template" from the title
* Removed the directions and checklist from the top (not intended to be carried over into the final report)
* Fixed all the links that gdoc->markdown had messed up
* Re-indented many bullets that were invalid markdown (you can't go from depth 1 to depth 3 without an intermediate 2)
* Added a link to our kubeCon EU 2021 maintainer track talk, which we forgot to do last night